### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A more robust touch for ActiveRecord associations.
 Add the gem to your Gemfile:
 
 ```ruby
-gem 'activetouch', '~> 4.0'
+gem 'active_touch', '~> 4.0'
 ```
 
 Then run the installer:


### PR DESCRIPTION
The `README` seems to show the wrong gem name ([rubygems](https://rubygems.org/gems/active_touch))